### PR TITLE
Jump automatically when maxJumpTimer is reached

### DIFF
--- a/Player.js
+++ b/Player.js
@@ -779,6 +779,8 @@ class Player {
     UpdateJumpTimer() {
         if (this.isOnGround && this.jumpHeld && this.jumpTimer < maxJumpTimer) {
             this.jumpTimer += 1
+        } else if (this.jumpTimer >= maxJumpTimer) {
+            this.Jump();
         }
     }
 


### PR DESCRIPTION
The full game jumps you automatically when you've held the button down long enough. Not an issue for bot players but makes the game feel more accurate for human players